### PR TITLE
Fix impossible if condition

### DIFF
--- a/src/header.c
+++ b/src/header.c
@@ -50,7 +50,7 @@ int pq_unified_header_read(FILE *stream_in, pq_header_t *pq_header,
 	if ( result != sizeof(magic) ) {
 		error("Could not read magic bytes\n");
 	} else {
-		if ( ! strncmp(magic, "PQTTTR", 6) || ! strncmp(magic, "PQHIST", 6) ) {
+		if ( ! strncmp(magic, "PQTTTR", 6) && ! strncmp(magic, "PQHIST", 6) ) {
 			memcpy(&(pu_header->Ident[0]), magic, 8*sizeof(char));
 			memcpy(&(pu_header->Version[0]), &(magic[8]), 8*sizeof(char));
 			debug("Ident: %.*s\n", 8, pu_header->Ident);


### PR DESCRIPTION
I'm not sure what the original intent was, but the if condition here could never be true.

For example, assume `magic = "PQHISTO"`. Then, the if condition would evaluate to `( ! false || ! true )`,
which is `( true || false )`, aka. `true`.

This PR just changes the `||` to `&&`, which I assume was the original intent.